### PR TITLE
Add autolayout to scrollview

### DIFF
--- a/swift/prototype04/prototype04/Base.lproj/Main.storyboard
+++ b/swift/prototype04/prototype04/Base.lproj/Main.storyboard
@@ -881,7 +881,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="uyt-Sa-NcQ" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-339" y="1081"/>
+            <point key="canvasLocation" x="-369" y="1081"/>
         </scene>
         <!--Main View Controller-->
         <scene sceneID="azl-uf-wH7">
@@ -1276,7 +1276,7 @@
                                                                         <rect key="frame" x="0.0" y="28" width="320" height="44"/>
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="vXL-N6-lec" id="zJD-Te-THT">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                                                             <autoresizingMask key="autoresizingMask"/>
                                                                         </tableViewCellContentView>
                                                                     </tableViewCell>
@@ -1716,7 +1716,7 @@
                                                         <rect key="frame" x="0.0" y="28" width="320" height="70"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="sZR-PN-mND" id="qu7-wS-9Gv">
-                                                            <rect key="frame" x="0.0" y="0.0" width="320" height="69"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="320" height="69.5"/>
                                                             <autoresizingMask key="autoresizingMask"/>
                                                             <subviews>
                                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="dxs-7n-fmY">
@@ -3542,134 +3542,228 @@
             </objects>
             <point key="canvasLocation" x="5370" y="144"/>
         </scene>
+        <!--View Controller-->
+        <scene sceneID="zuJ-bV-wNQ">
+            <objects>
+                <viewController id="i2r-Q5-2PU" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="db1-NG-M7m"/>
+                        <viewControllerLayoutGuide type="bottom" id="9Qs-VQ-N2c"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="oSe-Va-URy">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="1000"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="何をやっているのか" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vfb-ge-gPd">
+                                <rect key="frame" x="82" y="65" width="156" height="21"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" ambiguous="YES" scrollEnabled="NO" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WCz-uB-CHn">
+                                <rect key="frame" x="92" y="101" width="220" height="67"/>
+                                <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="220" id="wTg-uK-ISG"/>
+                                </constraints>
+                                <string key="text">弊社ででは、月に数本のアプリのデザインをしています。 基本的に弊社ではエンジニアと高頻度に連絡をとりながら、サービスの開発を行っております。
+</string>
+                                <color key="textColor" red="0.20000000300000001" green="0.20000000300000001" blue="0.20000000300000001" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="経歴" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fej-08-9lh">
+                                <rect key="frame" x="82" y="228" width="35" height="21"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" ambiguous="YES" scrollEnabled="NO" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xs5-MD-snc">
+                                <rect key="frame" x="92" y="318" width="220" height="83"/>
+                                <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="calibratedRGB"/>
+                                <string key="text">2014.3 バカ田大学卒業
+2015.4 前田工業入社
+2017.3 前田工業退社
+2017.4 現職</string>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="前職について" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fry-ik-60p">
+                                <rect key="frame" x="82" y="461" width="104" height="21"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" ambiguous="YES" scrollEnabled="NO" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e6I-zD-xbD">
+                                <rect key="frame" x="92" y="502" width="220" height="67"/>
+                                <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="calibratedRGB"/>
+                                <string key="text">前職ではDMM.comでデザイナーとして５年間働いていました。
+そこでは、Webサイトのデザインをメインとし、ビデオサイトから、英会話サービスまで、約２０種類のサイトのデザインを担当しました。
+</string>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="メッセージ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oNZ-FA-ajT">
+                                <rect key="frame" x="82" y="622" width="72" height="17"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
+                                <color key="textColor" red="0.20000000300000001" green="0.20000000300000001" blue="0.20000000300000001" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pO6-dZ-nk1">
+                                <rect key="frame" x="92" y="655" width="220" height="374"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <string key="text">はじめまして、現在株式会社ヤフーで働く山田太郎といいます！ 現在弊社では、エンジニアの採用を急激に高めていますので、もしご興味ある方は
+ご連絡ください！！</string>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="e6I-zD-xbD" firstAttribute="top" secondItem="fry-ik-60p" secondAttribute="bottom" constant="20" id="6kX-52-SEe"/>
+                            <constraint firstItem="fry-ik-60p" firstAttribute="top" secondItem="xs5-MD-snc" secondAttribute="bottom" constant="60" id="BsA-m5-m1g"/>
+                            <constraint firstItem="Fej-08-9lh" firstAttribute="top" secondItem="WCz-uB-CHn" secondAttribute="bottom" constant="60" id="MvQ-0E-Aqg"/>
+                            <constraint firstItem="WCz-uB-CHn" firstAttribute="top" secondItem="vfb-ge-gPd" secondAttribute="bottom" constant="15" id="OMa-CO-CVJ"/>
+                            <constraint firstItem="pO6-dZ-nk1" firstAttribute="top" secondItem="oNZ-FA-ajT" secondAttribute="bottom" constant="16" id="OPU-cU-6o2"/>
+                            <constraint firstItem="xs5-MD-snc" firstAttribute="top" secondItem="Fej-08-9lh" secondAttribute="bottom" constant="69" id="hXo-Tf-Cud"/>
+                            <constraint firstItem="oNZ-FA-ajT" firstAttribute="top" secondItem="e6I-zD-xbD" secondAttribute="bottom" constant="53" id="rpd-bO-4dx"/>
+                        </constraints>
+                    </view>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="320" height="1000"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="LY1-pV-qWn" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1453" y="2047"/>
+        </scene>
         <!--Recruiter Personal View Controller-->
         <scene sceneID="Zb5-Ws-lmg">
             <objects>
                 <viewController id="EUi-u1-QTJ" customClass="RecruiterPersonalViewController" customModule="prototype04" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="A6k-04-Cof"/>
-                        <viewControllerLayoutGuide type="bottom" id="p8F-9a-TR9"/>
+                        <viewControllerLayoutGuide type="top" id="fpi-05-1nn"/>
+                        <viewControllerLayoutGuide type="bottom" id="GGB-qp-GJn"/>
                     </layoutGuides>
-                    <scrollView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" id="04J-zQ-b6d">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="533"/>
+                    <view key="view" contentMode="scaleToFill" id="uHV-5m-f7Z">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="1000"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hBk-E0-Ws0">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="1066"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UMy-ct-70x">
+                                <rect key="frame" x="0.0" y="0.0" width="320" height="1000"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="何をやっているのか" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qmz-6g-Xwz">
-                                        <rect key="frame" x="40" y="20" width="156" height="21"/>
-                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JQM-aQ-4hO">
-                                        <rect key="frame" x="50" y="56" width="220" height="128"/>
-                                        <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="calibratedRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="128" id="sTz-U9-1Fx"/>
-                                        </constraints>
-                                        <string key="text">弊社ででは、月に数本のアプリのデザインをしています。 基本的に弊社ではエンジニアと高頻度に連絡をとりながら、サービスの開発を行っております。
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W6w-fI-9Pl">
+                                        <rect key="frame" x="0.0" y="0.0" width="320" height="942.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="何をやっているのか" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x0b-Fs-h4P">
+                                                <rect key="frame" x="45" y="40" width="156" height="21"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="経歴" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4ZY-VC-BQA">
+                                                <rect key="frame" x="45" y="259.5" width="35" height="21"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="前職について" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7h2-b7-7wR">
+                                                <rect key="frame" x="45" y="490" width="104" height="21"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eds-FV-RfY">
+                                                <rect key="frame" x="30" y="94" width="260" height="122"/>
+                                                <string key="text">弊社ででは、月に数本のアプリのデザインをしています。 基本的に弊社ではエンジニアと高頻度に連絡をとりながら、サービスの開発を行っております。
 </string>
-                                        <color key="textColor" red="0.20000000300000001" green="0.20000000300000001" blue="0.20000000300000001" alpha="1" colorSpace="calibratedRGB"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                    </textView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="経歴" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lsq-NI-AWq">
-                                        <rect key="frame" x="40" y="244" width="35" height="21"/>
-                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cs8-Tg-Bqa">
-                                        <rect key="frame" x="50" y="273" width="220" height="100"/>
-                                        <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="calibratedRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="100" id="EaT-C0-5rI"/>
-                                        </constraints>
-                                        <string key="text">2014.3 バカ田大学卒業
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BuZ-qA-2Cl">
+                                                <rect key="frame" x="30" y="334" width="260" height="82"/>
+                                                <string key="text">2014.3 バカ田大学卒業
 2015.4 前田工業入社
 2017.3 前田工業退社
 2017.4 現職</string>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                    </textView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="前職について" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ePV-dU-WuW">
-                                        <rect key="frame" x="40" y="433" width="104" height="21"/>
-                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GMx-rA-fIS">
-                                        <rect key="frame" x="50" y="457" width="220" height="128"/>
-                                        <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="calibratedRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="128" id="9Es-X9-exr"/>
-                                        </constraints>
-                                        <string key="text">前職ではDMM.comでデザイナーとして５年間働いていました。
-そこでは、Webサイトのデザインをメインとし、ビデオサイトから、英会話サービスまで、約２０種類のサイトのデザインを担当しました。
-</string>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                    </textView>
-                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AUE-t9-4gB">
-                                        <rect key="frame" x="50" y="645" width="220" height="128"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                        <string key="text">はじめまして、現在株式会社ヤフーで働く山田太郎といいます！ 現在弊社では、エンジニアの採用を急激に高めていますので、もしご興味ある方は
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lgw-Pc-vw9">
+                                                <rect key="frame" x="30" y="571" width="260" height="142.5"/>
+                                                <string key="text">前職ではDMM.comでデザイナーとして５年間働いていました。
+そこでは、Webサイトのデザインをメインとし、ビデオサイトから、英会話サービスまで、約２０種類のサイトのデザインを担当しました。</string>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bbJ-IK-Amw">
+                                                <rect key="frame" x="30" y="790.5" width="260" height="122"/>
+                                                <string key="text">はじめまして、現在株式会社ヤフーで働く山田太郎といいます！ 現在弊社では、エンジニアの採用を急激に高めていますので、もしご興味ある方は
 ご連絡ください！！</string>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                    </textView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="メッセージ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gau-7s-rTA">
-                                        <rect key="frame" x="40" y="638" width="72" height="17"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="メッセージ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pzn-hg-RPv">
+                                                <rect key="frame" x="45" y="743.5" width="72" height="17"/>
+                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
+                                                <color key="textColor" red="0.20000000300000001" green="0.20000000300000001" blue="0.20000000300000001" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
-                                        <color key="textColor" red="0.20000000300000001" green="0.20000000300000001" blue="0.20000000300000001" alpha="1" colorSpace="calibratedRGB"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
+                                        <constraints>
+                                            <constraint firstItem="bbJ-IK-Amw" firstAttribute="leading" secondItem="W6w-fI-9Pl" secondAttribute="leading" constant="30" id="6JS-On-61A"/>
+                                            <constraint firstAttribute="trailing" secondItem="Lgw-Pc-vw9" secondAttribute="trailing" constant="30" id="6kx-6A-QLA"/>
+                                            <constraint firstItem="eds-FV-RfY" firstAttribute="leading" secondItem="W6w-fI-9Pl" secondAttribute="leading" constant="30" id="9J9-5s-iVW"/>
+                                            <constraint firstItem="4ZY-VC-BQA" firstAttribute="top" secondItem="eds-FV-RfY" secondAttribute="bottom" constant="43.5" id="AqN-6z-UHb"/>
+                                            <constraint firstItem="7h2-b7-7wR" firstAttribute="top" secondItem="BuZ-qA-2Cl" secondAttribute="bottom" constant="74" id="BPE-HY-2f3"/>
+                                            <constraint firstItem="Lgw-Pc-vw9" firstAttribute="leading" secondItem="W6w-fI-9Pl" secondAttribute="leading" constant="30" id="IcV-PR-6Re"/>
+                                            <constraint firstItem="BuZ-qA-2Cl" firstAttribute="leading" secondItem="W6w-fI-9Pl" secondAttribute="leading" constant="30" id="PKV-6x-OvG"/>
+                                            <constraint firstItem="Pzn-hg-RPv" firstAttribute="top" secondItem="Lgw-Pc-vw9" secondAttribute="bottom" constant="30" id="SI1-Iz-dgf"/>
+                                            <constraint firstItem="4ZY-VC-BQA" firstAttribute="leading" secondItem="W6w-fI-9Pl" secondAttribute="leading" constant="45" id="V1a-zq-ORN"/>
+                                            <constraint firstAttribute="trailing" secondItem="bbJ-IK-Amw" secondAttribute="trailing" constant="30" id="VEm-77-tS8"/>
+                                            <constraint firstAttribute="trailing" secondItem="BuZ-qA-2Cl" secondAttribute="trailing" constant="30" id="bpa-GO-0rg"/>
+                                            <constraint firstItem="bbJ-IK-Amw" firstAttribute="top" secondItem="Pzn-hg-RPv" secondAttribute="bottom" constant="30" id="ddj-b9-0bY"/>
+                                            <constraint firstItem="x0b-Fs-h4P" firstAttribute="leading" secondItem="W6w-fI-9Pl" secondAttribute="leading" constant="45" id="e9X-zd-PqL"/>
+                                            <constraint firstItem="x0b-Fs-h4P" firstAttribute="top" secondItem="W6w-fI-9Pl" secondAttribute="top" constant="40" id="gIC-Oi-oFn"/>
+                                            <constraint firstItem="Pzn-hg-RPv" firstAttribute="leading" secondItem="W6w-fI-9Pl" secondAttribute="leading" constant="45" id="gXG-W7-RjY"/>
+                                            <constraint firstAttribute="bottom" secondItem="bbJ-IK-Amw" secondAttribute="bottom" constant="30" id="gs2-pa-8Wv"/>
+                                            <constraint firstAttribute="trailing" secondItem="eds-FV-RfY" secondAttribute="trailing" constant="30" id="q9k-1l-UxM"/>
+                                            <constraint firstItem="Lgw-Pc-vw9" firstAttribute="top" secondItem="7h2-b7-7wR" secondAttribute="bottom" constant="60" id="utL-JH-22g"/>
+                                            <constraint firstItem="BuZ-qA-2Cl" firstAttribute="top" secondItem="4ZY-VC-BQA" secondAttribute="bottom" constant="53.5" id="xSi-Ut-NnK"/>
+                                            <constraint firstItem="7h2-b7-7wR" firstAttribute="leading" secondItem="W6w-fI-9Pl" secondAttribute="leading" constant="45" id="xck-fM-ezy"/>
+                                            <constraint firstItem="eds-FV-RfY" firstAttribute="top" secondItem="x0b-Fs-h4P" secondAttribute="bottom" constant="33" id="ybL-8H-VzM"/>
+                                        </constraints>
+                                    </view>
                                 </subviews>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
-                                    <constraint firstItem="AUE-t9-4gB" firstAttribute="top" secondItem="gau-7s-rTA" secondAttribute="top" constant="7" id="519-Yz-iFp"/>
-                                    <constraint firstItem="gau-7s-rTA" firstAttribute="leading" secondItem="ePV-dU-WuW" secondAttribute="leading" id="67R-9l-k4Z"/>
-                                    <constraint firstItem="lsq-NI-AWq" firstAttribute="leading" secondItem="qmz-6g-Xwz" secondAttribute="leading" id="6oh-0x-681"/>
-                                    <constraint firstItem="AUE-t9-4gB" firstAttribute="width" secondItem="GMx-rA-fIS" secondAttribute="width" id="7pS-w1-z9r"/>
-                                    <constraint firstItem="AUE-t9-4gB" firstAttribute="leading" secondItem="GMx-rA-fIS" secondAttribute="leading" id="B8N-oE-Ody"/>
-                                    <constraint firstItem="qmz-6g-Xwz" firstAttribute="leading" secondItem="hBk-E0-Ws0" secondAttribute="leading" constant="40" id="CgV-8i-lTI"/>
-                                    <constraint firstItem="JQM-aQ-4hO" firstAttribute="top" secondItem="qmz-6g-Xwz" secondAttribute="bottom" constant="15" id="J85-NC-U59"/>
-                                    <constraint firstItem="AUE-t9-4gB" firstAttribute="top" secondItem="GMx-rA-fIS" secondAttribute="bottom" constant="60" id="JxR-JU-USi"/>
-                                    <constraint firstItem="Cs8-Tg-Bqa" firstAttribute="leading" secondItem="lsq-NI-AWq" secondAttribute="leading" constant="10" id="RAN-4R-BnK"/>
-                                    <constraint firstItem="lsq-NI-AWq" firstAttribute="top" secondItem="JQM-aQ-4hO" secondAttribute="bottom" constant="60" id="ad5-2l-fog"/>
-                                    <constraint firstItem="JQM-aQ-4hO" firstAttribute="leading" secondItem="hBk-E0-Ws0" secondAttribute="leading" constant="50" id="gDQ-6c-Lzg"/>
-                                    <constraint firstItem="Cs8-Tg-Bqa" firstAttribute="centerX" secondItem="hBk-E0-Ws0" secondAttribute="centerX" id="gaR-QA-LQN"/>
-                                    <constraint firstItem="GMx-rA-fIS" firstAttribute="centerX" secondItem="hBk-E0-Ws0" secondAttribute="centerX" id="gxr-AE-fGQ"/>
-                                    <constraint firstItem="qmz-6g-Xwz" firstAttribute="top" secondItem="hBk-E0-Ws0" secondAttribute="top" constant="20" id="j0f-Hb-nlw"/>
-                                    <constraint firstItem="GMx-rA-fIS" firstAttribute="top" secondItem="ePV-dU-WuW" secondAttribute="bottom" constant="3" id="jNR-Ut-M7X"/>
-                                    <constraint firstItem="ePV-dU-WuW" firstAttribute="leading" secondItem="lsq-NI-AWq" secondAttribute="leading" id="mDu-Ra-liM"/>
-                                    <constraint firstItem="AUE-t9-4gB" firstAttribute="height" secondItem="GMx-rA-fIS" secondAttribute="height" id="n1Y-VW-ktg"/>
-                                    <constraint firstItem="GMx-rA-fIS" firstAttribute="leading" secondItem="hBk-E0-Ws0" secondAttribute="leading" constant="50" id="poc-a5-2Xu"/>
-                                    <constraint firstItem="Cs8-Tg-Bqa" firstAttribute="top" secondItem="lsq-NI-AWq" secondAttribute="bottom" constant="8" id="rdh-x4-qcJ"/>
-                                    <constraint firstItem="JQM-aQ-4hO" firstAttribute="centerX" secondItem="hBk-E0-Ws0" secondAttribute="centerX" id="vDs-Vh-rW5"/>
-                                    <constraint firstItem="ePV-dU-WuW" firstAttribute="top" secondItem="Cs8-Tg-Bqa" secondAttribute="bottom" constant="60" id="vK6-no-52A"/>
+                                    <constraint firstAttribute="bottom" secondItem="W6w-fI-9Pl" secondAttribute="bottom" id="EmL-RP-oP3"/>
+                                    <constraint firstItem="W6w-fI-9Pl" firstAttribute="width" secondItem="UMy-ct-70x" secondAttribute="width" id="ULa-pt-pYg"/>
+                                    <constraint firstItem="W6w-fI-9Pl" firstAttribute="leading" secondItem="UMy-ct-70x" secondAttribute="leading" id="aTD-AU-Wrb"/>
+                                    <constraint firstItem="W6w-fI-9Pl" firstAttribute="top" secondItem="UMy-ct-70x" secondAttribute="top" id="oZM-BC-kZi"/>
+                                    <constraint firstAttribute="trailing" secondItem="W6w-fI-9Pl" secondAttribute="trailing" id="ssq-5H-Hbh"/>
                                 </constraints>
-                            </view>
+                            </scrollView>
                         </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="hBk-E0-Ws0" secondAttribute="trailing" id="7bm-uV-UGG"/>
-                            <constraint firstItem="hBk-E0-Ws0" firstAttribute="leading" secondItem="04J-zQ-b6d" secondAttribute="leading" id="Do7-eG-a7k"/>
-                            <constraint firstAttribute="bottom" secondItem="hBk-E0-Ws0" secondAttribute="bottom" id="Hgy-PR-pEx"/>
-                            <constraint firstItem="hBk-E0-Ws0" firstAttribute="top" secondItem="04J-zQ-b6d" secondAttribute="top" id="MRl-fD-lKK"/>
-                            <constraint firstItem="hBk-E0-Ws0" firstAttribute="height" secondItem="04J-zQ-b6d" secondAttribute="height" multiplier="2" id="i6Q-lh-fw3"/>
-                            <constraint firstItem="hBk-E0-Ws0" firstAttribute="width" secondItem="04J-zQ-b6d" secondAttribute="width" id="w4f-3o-aGI"/>
+                            <constraint firstAttribute="trailing" secondItem="UMy-ct-70x" secondAttribute="trailing" id="8sh-hP-Yun"/>
+                            <constraint firstItem="UMy-ct-70x" firstAttribute="top" secondItem="fpi-05-1nn" secondAttribute="bottom" id="NcY-ia-JFK"/>
+                            <constraint firstItem="GGB-qp-GJn" firstAttribute="top" secondItem="UMy-ct-70x" secondAttribute="bottom" id="fPV-Tc-OUs"/>
+                            <constraint firstItem="UMy-ct-70x" firstAttribute="leading" secondItem="uHV-5m-f7Z" secondAttribute="leading" id="nfu-3c-YJX"/>
                         </constraints>
-                    </scrollView>
-                    <connections>
-                        <outlet property="recruiterMessageView" destination="AUE-t9-4gB" id="A1o-6R-tOO"/>
-                    </connections>
+                    </view>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="320" height="1000"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5mS-I4-dsD" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-392" y="1887"/>
+            <point key="canvasLocation" x="-622.5" y="2131.6901408450703"/>
         </scene>
         <!--Company View Controller-->
         <scene sceneID="aFg-O3-utN">
@@ -3934,7 +4028,7 @@ Yahoo! JAPANは、2017年度もさらなる進化を遂げていきます。</st
                                                                         <rect key="frame" x="0.0" y="28" width="320" height="44"/>
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Elc-Fb-YY4" id="d9i-yZ-VCk">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                                                             <autoresizingMask key="autoresizingMask"/>
                                                                         </tableViewCellContentView>
                                                                     </tableViewCell>
@@ -4229,7 +4323,7 @@ Yahoo! JAPANは、2017年度もさらなる進化を遂げていきます。</st
                                                         <rect key="frame" x="0.0" y="28" width="320" height="70"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="FLO-jX-NXr" id="qQm-T9-QMK">
-                                                            <rect key="frame" x="0.0" y="0.0" width="320" height="69"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="320" height="69.5"/>
                                                             <autoresizingMask key="autoresizingMask"/>
                                                             <subviews>
                                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="alL-dp-4LY">
@@ -4407,6 +4501,10 @@ Yahoo! JAPANは、2017年度もさらなる進化を遂げていきます。</st
         <scene sceneID="Pm8-1G-3EU">
             <objects>
                 <viewController id="eOm-MP-iiL" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="4Mu-Fc-yK4"/>
+                        <viewControllerLayoutGuide type="bottom" id="5Lc-Op-etB"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="u1D-QX-pEJ">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -4421,6 +4519,10 @@ Yahoo! JAPANは、2017年度もさらなる進化を遂げていきます。</st
         <scene sceneID="xdC-LS-mxU">
             <objects>
                 <viewController id="IGi-mU-Q2r" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="R4N-qA-oxc"/>
+                        <viewControllerLayoutGuide type="bottom" id="fLB-GF-p6m"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8U7-Uy-XYz">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -4435,6 +4537,10 @@ Yahoo! JAPANは、2017年度もさらなる進化を遂げていきます。</st
         <scene sceneID="wmL-lD-Hsp">
             <objects>
                 <viewController id="ysm-qF-N3x" customClass="MessageViewControllerTest" customModule="prototype04" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="qea-ml-stE"/>
+                        <viewControllerLayoutGuide type="bottom" id="7uA-II-4Gg"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="899-we-Ok5">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/swift/prototype04/prototype04/RecruiterPersonalViewController.swift
+++ b/swift/prototype04/prototype04/RecruiterPersonalViewController.swift
@@ -10,14 +10,14 @@ import UIKit
 
 class RecruiterPersonalViewController: UIViewController {
 
-    @IBOutlet weak var recruiterMessageView: UITextView!
+//    @IBOutlet weak var recruiterMessageView: UITextView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        recruiterMessageView.layer.borderWidth = 1
-        recruiterMessageView.layer.masksToBounds = true
-        recruiterMessageView.layer.cornerRadius = 5
+//        recruiterMessageView.layer.borderWidth = 1
+//        recruiterMessageView.layer.masksToBounds = true
+//        recruiterMessageView.layer.cornerRadius = 5
         
         // Do any additional setup after loading the view.
     }


### PR DESCRIPTION
これ難しいな・・・

まず基本として中身のサイズによってscrollviewのサイズを自動的に決めるにはscrollviewの中のviewが固定の高さをautolayoutで決められるように制約を設定すれば良い。

例えば下記のような階層にする
- View
	- ScrollView
		- View(ContentView)
			- 中身
			- 中身
			- 中身

ScrollViewに上下左右マージン0を設定
ContentViewに上下左右マージン0を設定＋ScrollViewとequal widthを設定
中身について上から下までマージを設定

で中身のサイズによってScroll領域が自動的に決まるようになる。

詳しくは下記を参考
http://whiskmobile.com/post/130915367616/uiscrollview-with-auto-layout

※ただし、罠があって今回中身にTextViewが入っていたのでAutoLayoutだけ制約を決めるのが非常に難しかった。なので今回TextViewをLabelに置き換えている。（TextViewもScrollViewの一種なので中身のテキストの分量よって高さを決めることができない。Labelは文字列の分量次第で固有の高さが自動的に決まる。Labelの代わりにTextViewを使いたいならheightに固定値を設定することで使える）

で、これでいけるはずだったんだけど動作確認してみるとまだうまくいってない（下の方まで完全にスクロールできない）。

試しにRecruiterPersonalViewControllerのis initial View Controllerにチェックを入れて動作確認するとこちらはうまくいく。なのでAutoLayoutの設定自体は問題なくてContainerViewの中にScrollViewを使うには何か設定が足りないのかもしれない。。。というとこまでわかった。

続きはまた